### PR TITLE
Add shebang to executable file

### DIFF
--- a/bin/quickconvert.js
+++ b/bin/quickconvert.js
@@ -1,4 +1,4 @@
-
+#/usr/bin/env node
 const fs = require('fs')
     , path = require('path')
     , { Converter, getVariables } = require('../index')


### PR DESCRIPTION
Bin file currently lacks shebang, running it results in syntax errors (because it tries to run as shell, I guess).
See [npm bin docs](https://docs.npmjs.com/files/package.json#bin):

> Please make sure that your file(s) referenced in `bin` starts with `#!/usr/bin/env node`, otherwise the scripts are started without the node executable!

 